### PR TITLE
update readme with a valid window key prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ This repo provides wallet builders a pre-made class with all required wallet fun
 
 - Change `window.aptos` to be `window.<your-wallet-name>`
 
-> **_NOTE:_** make sure the `name` prop is the same as the `window.<name>` as the adapter is looking for your `name` prop when trying to detect a wallet in the browser. i.e if your `AptosWalletName` is `Aptos`, the `name` in `window.<name>` should be `Aptos`.
-  - Make sure the `Window Interface` has `<your-wallet-name>` as a key (instead of `aptos`)
+> **_NOTE:_** Ensure the `name` prop is the same as the `window.<name>`. The adapter will look for the matching name when detecting a wallet. For example, if your wallet's name prop is `Petra`, then the window should be `window.petra`.
+
+- Make sure the `Window Interface` has `<your-wallet-name>` as a key (instead of `aptos`)
 - Open `__tests/index.test.tsx` and change `AptosWallet` to `<Your-Wallet-Name>Wallet`
 - Run tests with `npm run test` - all tests should pass
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repo provides wallet builders a pre-made class with all required wallet fun
 - Change `icon` to your wallet icon (pay attention to the required format)
 
 - Change `window.aptos` to be `window.<your-wallet-name>`
+
+> **_NOTE:_** make sure the `name` prop is the same as the `window.<name>` as the adapter is looking for your `name` prop when trying to detect a wallet in the browser. i.e if your `AptosWalletName` is `Aptos`, the `name` in `window.<name>` should be `Aptos`.
   - Make sure the `Window Interface` has `<your-wallet-name>` as a key (instead of `aptos`)
 - Open `__tests/index.test.tsx` and change `AptosWallet` to `<Your-Wallet-Name>Wallet`
 - Run tests with `npm run test` - all tests should pass

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This repo provides wallet builders a pre-made class with all required wallet fun
 
 > **_NOTE:_** Ensure the `name` prop is the same as the `window.<name>`. The adapter will look for the matching name when detecting a wallet. For example, if your wallet's name prop is `Petra`, then the window should be `window.petra`.
 
+> **_NOTE2_** window object key (i.e `window.<name>`) has to be lowercase exact match (`petra`). Wallet name prop can have capitalization (`Petra` / `PetraWallet`)
+
 - Make sure the `Window Interface` has `<your-wallet-name>` as a key (instead of `aptos`)
 - Open `__tests/index.test.tsx` and change `AptosWallet` to `<Your-Wallet-Name>Wallet`
 - Run tests with `npm run test` - all tests should pass

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { Types } from "aptos";
 
 // CHANGE AptosWindow
 interface AptosWindow extends Window {
-  aptos?: PluginProvider; // CHANGE aptos key (should be the same as the wallet's name prop)
+  aptos?: PluginProvider; // CHANGE aptos key (has to be lowercase exact match and same as the wallet's name prop)
 }
 
 declare const window: AptosWindow; // CHANGE AptosWindow
@@ -24,7 +24,7 @@ export const AptosWalletName = "Aptos" as WalletName<"Aptos">; // CHANGE AptosWa
 
 // CHANGE AptosWallet
 export class AptosWallet implements AdapterPlugin {
-  readonly name = AptosWalletName; // CHANGE AptosWalletName
+  readonly name = AptosWalletName; // CHANGE AptosWalletName (can have capitalization)
   readonly url = // CHANGE url value
     "https://chrome.google.com/webstore/detail/petra-aptos-wallet/ejjladinnckdgjemekebdpeokbikhfci";
   readonly icon = // CHANGE icon value

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import { Types } from "aptos";
 
 // CHANGE AptosWindow
 interface AptosWindow extends Window {
-  aptos?: PluginProvider; // CHANGE aptos key
+  aptos?: PluginProvider; // CHANGE aptos key (should be the same as the wallet's name prop)
 }
 
 declare const window: AptosWindow; // CHANGE AptosWindow


### PR DESCRIPTION
Ensure `name` prop is the same as the `window.<name>`. The adapter will look for the matching name when detecting a wallet. For example, if your wallet's name prop is `Petra`, then the window should be `window.petra`.

window object key (i.e `window.<name>`) has to be lowercase exact match (`petra`). Wallet name prop can have capitalization (`Petra` / `PetraWallet`)